### PR TITLE
Fix divide by zero in evaluation

### DIFF
--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -150,7 +150,11 @@ class AlgorithmicTaskTrainer:
                 total_predictions += total
         
         # Compute average loss and accuracy
-        avg_loss = total_loss / len(self.test_dataloader)
+        num_batches = len(self.test_dataloader)
+        if num_batches == 0:
+            return float("nan"), 0.0
+
+        avg_loss = total_loss / num_batches
         avg_accuracy = correct_predictions / total_predictions if total_predictions > 0 else 0.0
         
         return avg_loss, avg_accuracy

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,0 +1,37 @@
+import math
+import pytest
+
+# Skip tests if torch is not installed
+torch = pytest.importorskip("torch")
+from torch.utils.data import TensorDataset
+
+from src.models.transformer import SimpleTransformer, TransformerConfig
+from src.training.trainer import AlgorithmicTaskTrainer
+
+
+def test_evaluate_returns_nan_for_empty_test_dataloader():
+    config = TransformerConfig(vocab_size=10, hidden_size=8, num_hidden_layers=1,
+                               num_attention_heads=2, intermediate_size=32)
+    model = SimpleTransformer(config)
+
+    # minimal train dataset so dataloader can initialize
+    train_inputs = torch.randint(0, config.vocab_size - 1, (1, 2))
+    train_targets = torch.randint(0, config.vocab_size - 1, (1, 2))
+    train_dataset = TensorDataset(train_inputs, train_targets)
+
+    # empty test dataset
+    test_inputs = torch.empty((0, 2), dtype=torch.long)
+    test_targets = torch.empty((0, 2), dtype=torch.long)
+    test_dataset = TensorDataset(test_inputs, test_targets)
+
+    trainer = AlgorithmicTaskTrainer(
+        model=model,
+        train_dataset=train_dataset,
+        test_dataset=test_dataset,
+        batch_size=1,
+        max_epochs=1,
+    )
+    loss, acc = trainer.evaluate()
+
+    assert math.isnan(loss)
+    assert acc == 0.0


### PR DESCRIPTION
## Summary
- prevent division by zero when the test dataloader is empty
- add a pytest to cover the empty dataloader case

## Testing
- `python -m py_compile $(git ls-files '*.py')`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where evaluating with an empty test dataset could cause errors. The system now returns NaN for loss and 0.0 for accuracy in this case.

- **Tests**
  - Added a test to verify that evaluation with an empty test dataset returns the expected values (NaN loss, 0.0 accuracy).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->